### PR TITLE
fix: set exec artifact only if it was previously unset

### DIFF
--- a/entrypoint/client/client.go
+++ b/entrypoint/client/client.go
@@ -92,7 +92,7 @@ func (c *Client) Config(netCfg *network.Network) (*network.Network, error) {
 		}
 
 		for _, node := range netCfg.Nodes {
-			if node.GetExecArtifact() != "" {
+			if node.GetExecArtifact() == "" {
 				node.SetExecArtifact(path)
 			}
 		}


### PR DESCRIPTION
## Describe your changes

This PR allows us  to easily inject nodes with other build configs into the network

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have executed relevant tests
- [ ] I have added thorough tests for the changes
- [ ] Does this need a documentation update?

