### PR TITLE
Remove unused Node Types and default certain configs to avoid repetition

### DIFF
--- a/environments/local/local.go
+++ b/environments/local/local.go
@@ -244,9 +244,6 @@ func (l *Local) checkNode(n node.Config) error {
 func (l *Local) AttachToPublicNetworkAndStart(config PublicNetworkConfig) error {
 	publicNode := &node.BaseNode{
 		ID:             config.NodeID,
-		APICORS:        "*",
-		Type:           node.RegularNode,
-		Verbosity:      3,
 		P2PListenPort:  config.P2PPort,
 		APIAddr:        config.APIAddr,
 		AdditionalArgs: map[string]string{"network": config.NetworkType},

--- a/environments/local/local_test.go
+++ b/environments/local/local_test.go
@@ -453,9 +453,6 @@ func testPublicNetworkConnection(t *testing.T, config publicNetworkTestConfig) {
 
 	publicNode := &node.BaseNode{
 		ID:             config.NodeID,
-		APICORS:        "*",
-		Type:           node.RegularNode,
-		Verbosity:      3,
 		P2PListenPort:  config.P2PPort,
 		APIAddr:        fmt.Sprintf("127.0.0.1:%d", config.APIPort),
 		AdditionalArgs: map[string]string{"network": config.NetworkType},
@@ -537,9 +534,6 @@ func testAttachNodeConnection(t *testing.T, config attachNodeTestConfig) {
 
 	initialNode := &node.BaseNode{
 		ID:             config.InitialNodeID,
-		APICORS:        "*",
-		Type:           node.RegularNode,
-		Verbosity:      3,
 		P2PListenPort:  config.InitialP2PPort,
 		APIAddr:        fmt.Sprintf("127.0.0.1:%d", config.InitialAPIPort),
 		AdditionalArgs: map[string]string{"network": config.NetworkType},
@@ -567,9 +561,6 @@ func testAttachNodeConnection(t *testing.T, config attachNodeTestConfig) {
 	// Create a new node to attach
 	attachNode := &node.BaseNode{
 		ID:             config.AttachNodeID,
-		APICORS:        "*",
-		Type:           node.RegularNode,
-		Verbosity:      3,
 		P2PListenPort:  config.AttachP2PPort,
 		APIAddr:        fmt.Sprintf("127.0.0.1:%d", config.AttachAPIPort),
 		AdditionalArgs: map[string]string{"network": config.NetworkType},

--- a/network/node/node.go
+++ b/network/node/node.go
@@ -6,11 +6,6 @@ import (
 	"github.com/vechain/networkhub/network/node/genesis"
 )
 
-const (
-	MasterNode  = "masterNode"
-	RegularNode = "regularNode"
-)
-
 type Config interface {
 	Enode(ipAddr string) (string, error)
 	SetExecArtifact(artifact string)

--- a/network/node/node_base.go
+++ b/network/node/node_base.go
@@ -24,13 +24,15 @@ type BaseNode struct {
 	P2PListenPort  int                    `json:"p2pListenPort"`
 	Verbosity      int                    `json:"verbosity"`
 	EnodeData      string                 `json:"enode"` // todo: this should be a generated method
-	Type           string                 `json:"type"`
 	FakeExecution  bool                   `json:"fakeExecution"`
 	Genesis        *genesis.CustomGenesis `json:"genesis"`
 	AdditionalArgs map[string]string      `json:"additionalArgs"`
 }
 
 func (b *BaseNode) GetVerbosity() int {
+	if b.Verbosity == 0 {
+		return 3
+	}
 	return b.Verbosity
 }
 

--- a/preset/LocalSixNodes.go
+++ b/preset/LocalSixNodes.go
@@ -126,9 +126,6 @@ func LocalSixNodesNetworkWithGenesis(genesis *genesis.CustomGenesis) *network.Ne
 				ID:            "node1",
 				P2PListenPort: 8061,
 				APIAddr:       "127.0.0.1:8161",
-				APICORS:       "*",
-				Type:          node.MasterNode,
-				Verbosity:     3,
 				Key:           "b2c859e115ef4a3f5e4d32228b41de4c661c527a32f723ac37745bf860fd09cb", // 0x5F90f56c7b87E3d1acf9437f0E43E4d687AcEB7e
 				Genesis:       genesis,
 			},
@@ -136,9 +133,6 @@ func LocalSixNodesNetworkWithGenesis(genesis *genesis.CustomGenesis) *network.Ne
 				ID:            "node2",
 				P2PListenPort: 8062,
 				APIAddr:       "127.0.0.1:8162",
-				APICORS:       "*",
-				Type:          node.MasterNode,
-				Verbosity:     3,
 				Key:           "4de650ca1c8beae4ed6a4358087f50c01b51f5c0002ae9836c55039ca9818d0c", // 0x5c29518F6a6124a2BeE89253347c8295f604710A
 				Genesis:       genesis,
 			},
@@ -146,8 +140,6 @@ func LocalSixNodesNetworkWithGenesis(genesis *genesis.CustomGenesis) *network.Ne
 				ID:            "node3",
 				P2PListenPort: 8063,
 				APIAddr:       "127.0.0.1:8163",
-				APICORS:       "*",
-				Type:          node.RegularNode,
 				Key:           "1b310ea04afd6d14a8f142158873fc70bfd4ba12a19138cc5b309fce7c77105e", // 0x1b1c0055065b3ADee4B9a9e8297142Ba2cD34EfE
 				Genesis:       genesis,
 			},
@@ -155,9 +147,6 @@ func LocalSixNodesNetworkWithGenesis(genesis *genesis.CustomGenesis) *network.Ne
 				ID:            "node4",
 				P2PListenPort: 8064,
 				APIAddr:       "127.0.0.1:8164",
-				APICORS:       "*",
-				Type:          node.MasterNode,
-				Verbosity:     3,
 				Key:           "c70dda88e779df10abbc7c5d37fbb3478c5cf8df2a70d6b0bfc551a5a9a17359", // 0x042306e116Dc301ecd7b83a04F4c8277Fbe41b6c
 				Genesis:       genesis,
 			},
@@ -165,9 +154,6 @@ func LocalSixNodesNetworkWithGenesis(genesis *genesis.CustomGenesis) *network.Ne
 				ID:            "node5",
 				P2PListenPort: 8065,
 				APIAddr:       "127.0.0.1:8165",
-				APICORS:       "*",
-				Type:          node.MasterNode,
-				Verbosity:     3,
 				Key:           "ade54b623a4f4afc38f962a85df07a428204a67cee0c9b43a99ca255fd2fb9a6", // 0x0aeC31606e217895696771961de416Efa185Be66
 				Genesis:       genesis,
 			},
@@ -175,8 +161,6 @@ func LocalSixNodesNetworkWithGenesis(genesis *genesis.CustomGenesis) *network.Ne
 				ID:            "node6",
 				P2PListenPort: 8066,
 				APIAddr:       "127.0.0.1:8166",
-				APICORS:       "*",
-				Type:          node.RegularNode,
 				Key:           "92ad65923d6782a43e6a1be01a8e52bce701967d78937e73da746a58f293ba30", // 0x9C2871C411CCe579B987E9b932C484dA8b901075
 				Genesis:       genesis,
 			},

--- a/preset/LocalThreeMasterNodes.go
+++ b/preset/LocalThreeMasterNodes.go
@@ -21,31 +21,22 @@ func LocalThreeMasterNodesNetwork() *network.Network {
 				ID:            "node1",
 				P2PListenPort: 8031,
 				APIAddr:       "127.0.0.1:8131",
-				APICORS:       "*",
-				Type:          node.MasterNode,
 				Key:           "01a4107bfb7d5141ec519e75788c34295741a1eefbfe460320efd2ada944071e", // 0x61fF580B63D3845934610222245C116E013717ec
 				Genesis:       genesis,
-				Verbosity:     3,
 			},
 			&node.BaseNode{
 				ID:            "node2",
 				P2PListenPort: 8032,
 				APIAddr:       "127.0.0.1:8132",
-				APICORS:       "*",
-				Type:          node.MasterNode,
 				Key:           "7072249b800ddac1d29a3cd06468cc1a917cbcd110dde358a905d03dad51748d", // 0x327931085B4cCbCE0baABb5a5E1C678707C51d90
 				Genesis:       genesis,
-				Verbosity:     3,
 			},
 			&node.BaseNode{
 				ID:            "node3",
 				P2PListenPort: 8033,
 				APIAddr:       "127.0.0.1:8133",
-				APICORS:       "*",
-				Type:          node.MasterNode,
 				Key:           "c55455943bf026dc44fcf189e8765eb0587c94e66029d580bae795386c0b737a", // 0x084E48c8AE79656D7e27368AE5317b5c2D6a7497
 				Genesis:       genesis,
-				Verbosity:     3,
 			},
 		},
 	}


### PR DESCRIPTION
## Describe your changes

As per title, Node Types are not really used and in hindsight the network definition does not depend on them.
The original idea was that the node type would generate the genesis, but this seems to be overly complicated.

Potentially useful in the future but right now it's adding unecessary complexity.

[Issue](https://github.com/vechain/otherviews-workboard/issues/212)

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have executed relevant tests
- [ ] I have added thorough tests for the changes
- [ ] Does this need a documentation update?

