### PR TITLE
fix: deprecated ecdsa.PrivateKey.D + full-tree lint on merges/releases

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -3,6 +3,11 @@ name: Lint
 on:
   # Should only be used by other workflows
   workflow_call:
+    inputs:
+      only-new-issues:
+        description: 'Report only issues on changed lines (PRs) vs. a full-tree scan (merges/releases)'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -21,8 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.3
-          # use the default if on main branch, otherwise use the pull request config
           args: --timeout=30m --config=.golangci.yml
-          only-new-issues: true
+          only-new-issues: ${{ inputs.only-new-issues }}
           skip-cache: true
 

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -3,7 +3,7 @@ name: Pull Request CI
 on:
   push:
     branches:
-      - 'master'
+      - main
   pull_request:
     branches:
       - main
@@ -16,4 +16,7 @@ jobs:
   lint:
     name: Lint
     uses: ./.github/workflows/lint-go.yaml
+    with:
+      # incremental on PRs; full-tree scan on merges to main
+      only-new-issues: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -21,3 +21,6 @@ jobs:
   lint:
     name: Lint
     uses: ./.github/workflows/lint-go.yaml
+    with:
+      # releases must full-scan, not rely on the tag-push diff fallback
+      only-new-issues: false

--- a/utils/common/common.go
+++ b/utils/common/common.go
@@ -41,7 +41,7 @@ type Account struct {
 }
 
 func (a Account) PrivateKeyString() string {
-	return fmt.Sprintf("%x", a.PrivateKey.D.Bytes()) //nolint:staticcheck
+	return fmt.Sprintf("%x", crypto.FromECDSA(a.PrivateKey))
 }
 
 type TxSendResult struct {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -16,7 +16,7 @@ func TestReadPK(t *testing.T) {
 	pubKeyA := privateKeyA.PublicKey
 	addrA := crypto.PubkeyToAddress(pubKeyA)
 	// Logging this to make sure if the test fails we have the culprit keys
-	t.Logf("PK String: %x\n", privateKeyA.D.Bytes()) //nolint:staticcheck
+	t.Logf("PK String: %x\n", crypto.FromECDSA(privateKeyA))
 	t.Logf("PK Address: %s", addrA.Hex())
 }
 
@@ -28,7 +28,7 @@ func TestGenerateData(t *testing.T) {
 	pubKeyA := privateKeyA.PublicKey
 	addrA := crypto.PubkeyToAddress(pubKeyA)
 	// Logging this to make sure if the test fails we have the culprit keys
-	t.Logf("PK String: %x\n", privateKeyA.D.Bytes())
+	t.Logf("PK String: %x\n", crypto.FromECDSA(privateKeyA))
 	t.Logf("PK Address: %s", addrA.Hex())
 }
 
@@ -41,7 +41,7 @@ func TestNodeID(t *testing.T) {
 	pubKeyA := privateKeyA.PublicKey
 	addrA := crypto.PubkeyToAddress(pubKeyA)
 	// Logging this to make sure if the test fails we have the culprit keys
-	t.Logf("PK String: %x\n", privateKeyA.D.Bytes())
+	t.Logf("PK String: %x\n", crypto.FromECDSA(privateKeyA))
 	t.Logf("PK Address: %s", addrA.Hex())
 
 	t.Logf("eNode: %s", fmt.Sprintf("enode://%x@[extip]:%v", discover.PubkeyID(&privateKeyA.PublicKey).Bytes(), 8080))


### PR DESCRIPTION
Fixes the release-blocking lint failure ([v0.0.9 run](https://github.com/vechain/networkhub/actions/runs/29927874127)) and closes the CI gap that let it reach a release undetected.

## 1. Code fix — deprecated `ecdsa.PrivateKey.D`
The `Lint / golangci-lint` job fails with `staticcheck` **SA1019**: `ecdsa.PrivateKey.D` was deprecated in Go 1.26. Four `.D.Bytes()` sites existed; two carried `//nolint:staticcheck`, but `utils_test.go:31` and `:44` were missed.

Replace all four with go-ethereum's `crypto.FromECDSA(priv)` and drop the `//nolint` directives.

**Bonus correctness fix:** `.D.Bytes()` returns the *minimal* big-endian scalar, so a key with a leading zero byte (~1/256) produced a non-canonical **<32-byte** hex string. `crypto.FromECDSA` always returns the 32-byte left-padded key. This matters for `common.Account.PrivateKeyString()`, whose output feeds node signing keys (`preset/local_four_nodes_hayabusa.go`) and is later parsed by `crypto.HexToECDSA`, which requires exactly 64 hex chars.

## 2. CI fix — why it wasn't caught on PRs
The lint job ran with `only-new-issues: true` everywhere, so it only inspected lines **changed in a PR**. A deprecation activated by a Go toolchain bump lands on *unchanged* lines, so it was invisible on PRs and only surfaced at release time (tag pushes implicitly full-scan) — after it had already reached a tag.

Changes:
- **`lint-go.yaml`** — add an `only-new-issues` input (default `true`) to the reusable workflow.
- **`on-pull-request.yaml`** — incremental on PRs, **full-tree scan on merges to `main`**. Also fixes the `push` trigger, which targeted a non-existent `master` branch (default is `main`) and never fired — so nothing re-lints post-merge today. Both lint + unit tests now run on merge to `main`.
- **`on-release.yaml`** — full-tree scan **explicitly**, rather than relying on the undocumented tag-push diff fallback.

Net behavior:
| Event | Lint | Tests |
|-------|------|-------|
| PR → main | incremental | ✅ |
| merge → main | **full-tree** | ✅ |
| release/tag | **full-tree** | ✅ |

## Verification
- `go build ./...`, `go vet ./...` ✅
- `golangci-lint` v2.11.3 (exact CI version), **clean cache**, full-tree `./...` → **0 issues** ✅ (verified it *does* flag the pre-fix code — earlier a stale cache masked it)
- `go test ./utils/... ./preset/...` ✅ (preset consumes `PrivateKeyString`)
- All three workflow YAMLs parse cleanly

Note: post-merge lint on `main` is advisory (a push can't be blocked); it flags latent issues within minutes of merge instead of at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)